### PR TITLE
fix bounds check in BinaryOutputReader

### DIFF
--- a/sim/sw/include/BinaryOutputReader.hpp
+++ b/sim/sw/include/BinaryOutputReader.hpp
@@ -45,9 +45,9 @@ private:
     void boundsCheck(uint64_t vaddr, uint64_t size) {
         bool bounds_check_success = false;
         for (auto &mapped_page : *mapped_pages) {
-            auto vaddr = reinterpret_cast<uint64_t>(mapped_page.first);
-            auto size = mapped_page.second.size;
-            if (vaddr <= vaddr && vaddr + size >= vaddr + size) {
+            auto mapped_page_vaddr = reinterpret_cast<uint64_t>(mapped_page.first);
+            auto mapped_page_size = mapped_page.second.size;
+            if (mapped_page_vaddr <= vaddr && mapped_page_vaddr + mapped_page_size >= vaddr + size) {
                 bounds_check_success = true;
             }
         }


### PR DESCRIPTION
## Description
boundsCheck function always returns true, because the local variables shadow the function arguments.

## Type of change
- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] A new research paper code implementation
- [ ] Other

## Tests & Results

### Checklist
- [ ] I have commented my code and made corresponding changes to the documentation.
- [ ] I have added tests/results that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings or errors & all tests successfully pass.
